### PR TITLE
Disable object cache use in `get_bylines()`

### DIFF
--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -23,16 +23,9 @@ function get_bylines( $post = null ) {
 		return array();
 	}
 	$taxonomy = 'byline';
-	$terms = get_object_term_cache( $post->ID, $taxonomy );
-	if ( false === $terms ) {
-		$terms = wp_get_object_terms( $post->ID, $taxonomy, array(
-			'orderby' => 'term_order',
-		) );
-		if ( ! is_wp_error( $terms ) ) {
-			$term_ids = wp_list_pluck( $terms, 'term_id' );
-			wp_cache_add( $post->ID, $term_ids, $taxonomy . '_relationships' );
-		}
-	}
+	$terms = wp_get_object_terms( $post->ID, $taxonomy, array(
+		'orderby' => 'term_order',
+	) );
 
 	/**
 	 * Filters the list of terms attached to the given post.


### PR DESCRIPTION
The object cache can contain incorrect byline order, so it's unreliable.
The performance impact of `wp_get_object_terms()` is negligible at this
point, so it's fine to use until core is fixed.

See #40