### PR TITLE
Add WPGraphQL support

### DIFF
--- a/bylines.php
+++ b/bylines.php
@@ -72,6 +72,7 @@ add_action( 'save_post', array( 'Bylines\Post_Editor', 'action_save_post_bylines
 // Integrations with other systems.
 add_filter( 'the_author', array( 'Bylines\Integrations\RSS', 'filter_the_author' ), 11 );
 add_action( 'rss2_item', array( 'Bylines\Integrations\RSS', 'action_rss2_item' ) );
+add_action( 'graphql_init', array( 'Bylines\Integrations\GraphQL\GraphQL', 'init' ) );
 
 if ( file_exists( dirname( __FILE__ ) . '/vendor/autoload.php' ) ) {
 	require_once dirname( __FILE__ ) . '/vendor/autoload.php';

--- a/src/Integrations/GraphQL/GraphQL.php
+++ b/src/Integrations/GraphQL/GraphQL.php
@@ -84,7 +84,7 @@ class GraphQL {
 				$bylines = get_bylines( $post );
 
 				return ! empty( $bylines ) ? $bylines : null;
-			}
+			},
 		];
 
 		return $fields;

--- a/src/Integrations/GraphQL/GraphQL.php
+++ b/src/Integrations/GraphQL/GraphQL.php
@@ -71,7 +71,7 @@ class GraphQL {
 	/**
 	 * This adds the byline field to the existing $fields definition
 	 *
-	 * @param $fields
+	 * @param array $fields Array of postObjectType fields
 	 *
 	 * @return mixed
 	 */
@@ -96,12 +96,14 @@ class GraphQL {
 	 * @return BylineType
 	 */
 	public static function byline_type() {
-		return self::$byline_type ? : ( self::$byline_type = new BylineType() );
+		$byline_type = self::$byline_type ? : ( self::$byline_type = new BylineType() );
+
+		return $byline_type;
 	}
 
 	/**
-	 * This filters the post object query args so that if the source of the query is a byline, the query should
-	 * be performed with a tax_query for the source byline.
+	 * This filters the post object query args so that if the source of the query is a byline, the query should be
+	 * performed with a tax_query for the source byline.
 	 *
 	 * @param array       $query_args The query_args that will be returned
 	 * @param array       $args       Query "where" args
@@ -141,9 +143,9 @@ class GraphQL {
 	/**
 	 * This filters the node resolver to properly resolve with the Byline object if the $type is "byline"
 	 *
-	 * @param $node
-	 * @param $id
-	 * @param $type
+	 * @param mixed|object|array $node The node to return
+	 * @param mixed|string|int   $id   The ID of the node
+	 * @param string             $type The type of node to resolve
 	 *
 	 * @return Byline|false
 	 */
@@ -151,6 +153,7 @@ class GraphQL {
 		if ( ! empty( $type ) && 'byline' === $type ) {
 			return Byline::get_by_term_id( $id );
 		}
+
 		return $node;
 	}
 
@@ -158,15 +161,16 @@ class GraphQL {
 	 * This filters the node_type to ensure that the Byline "type" is returned if the object being returned is
 	 * a Byline object
 	 *
-	 * @param $type
-	 * @param $node
+	 * @param string             $type The type of node being resolved
+	 * @param mixed|object|array $node The node being resolved
 	 *
-	 * @return BylineType
+	 * @return mixed|object|BylineType
 	 */
 	public function filter_resolve_node_type( $type, $node ) {
 		if ( is_object( $node ) && $node instanceof Byline ) {
 			return self::byline_type();
 		}
+
 		return $type;
 	}
 

--- a/src/Integrations/GraphQL/GraphQL.php
+++ b/src/Integrations/GraphQL/GraphQL.php
@@ -31,11 +31,11 @@ class GraphQL {
 	public static function init() {
 		add_action( 'do_graphql_request', array(
 			'Bylines\Integrations\GraphQL\GraphQL',
-			'filter_post_object_fields'
+			'filter_post_object_fields',
 		) );
 		add_filter( 'graphql_default_query_args', array(
 			'Bylines\Integrations\GraphQL\GraphQL',
-			'filter_byline_post_object_query_args'
+			'filter_byline_post_object_query_args',
 		), 10, 5 );
 		add_filter( 'graphql_resolve_node', array(
 			'Bylines\Integrations\GraphQL\GraphQL',
@@ -43,7 +43,7 @@ class GraphQL {
 		), 10, 3 );
 		add_filter( 'graphql_resolve_node_type', array(
 			'Bylines\Integrations\GraphQL\GraphQL',
-			'filter_resolve_node_type'
+			'filter_resolve_node_type',
 		), 10, 2 );
 	}
 
@@ -59,10 +59,10 @@ class GraphQL {
 
 		foreach ( $byline_post_types as $post_type ) {
 			if ( in_array( $post_type, $graphql_post_types, true ) ) {
-				add_filter( "graphql_{$post_type}_fields", [
+				add_filter( "graphql_{$post_type}_fields", array(
 					'Bylines\Integrations\GraphQL\GraphQL',
 					'post_object_fields'
-				], 10, 1 );
+				), 10, 1 );
 			}
 		}
 
@@ -119,13 +119,13 @@ class GraphQL {
 		if ( true === is_object( $source ) ) {
 			switch ( true ) {
 				case $source instanceof Byline:
-					$query_args['tax_query'] = [
-						[
+					$query_args['tax_query'] = array(
+						array(
 							'taxonomy' => 'byline',
 							'terms'    => [ $source->term_id ],
 							'field'    => 'term_id',
-						],
-					];
+						),
+					);
 					break;
 				default:
 					break;

--- a/src/Integrations/GraphQL/GraphQL.php
+++ b/src/Integrations/GraphQL/GraphQL.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Bylines\Integrations\GraphQL;
+
+use Bylines\Content_Model;
+use Bylines\Integrations\GraphQL\Type\BylineType;
+use Bylines\Objects\Byline;
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
+use WPGraphQL\Types;
+
+/**
+ * Class GraphQL
+ *
+ * This class organizes the functionality to connect Bylines to WPGraphQL
+ *
+ * @package Bylines\Integrations\GraphQL
+ */
+class GraphQL {
+
+	/**
+	 * Holds the instance of the BylineType
+	 *
+	 * @var BylineType
+	 */
+	private static $byline_type;
+
+	/**
+	 * This initializes the functionality connecting Bylines to WPGraphQL
+	 */
+	public static function init() {
+		add_action( 'do_graphql_request', array(
+			'Bylines\Integrations\GraphQL\GraphQL',
+			'filter_post_object_fields'
+		) );
+		add_filter( 'graphql_default_query_args', array(
+			'Bylines\Integrations\GraphQL\GraphQL',
+			'filter_byline_post_object_query_args'
+		), 10, 5 );
+		add_filter( 'graphql_resolve_node', array(
+			'Bylines\Integrations\GraphQL\GraphQL',
+			'filter_resolve_node',
+		), 10, 3 );
+		add_filter( 'graphql_resolve_node_type', array(
+			'Bylines\Integrations\GraphQL\GraphQL',
+			'filter_resolve_node_type'
+		), 10, 2 );
+	}
+
+	/**
+	 * This filters each postObjectType that has both GraphQL support and Bylines support, adding the byline fields
+	 *
+	 * @return void
+	 */
+	public static function filter_post_object_fields() {
+
+		$byline_post_types  = Content_Model::get_byline_supported_post_types();
+		$graphql_post_types = \WPGraphQL::get_allowed_post_types();
+
+		foreach ( $byline_post_types as $post_type ) {
+			if ( in_array( $post_type, $graphql_post_types, true ) ) {
+				add_filter( "graphql_{$post_type}_fields", [
+					'Bylines\Integrations\GraphQL\GraphQL',
+					'post_object_fields'
+				], 10, 1 );
+			}
+		}
+
+	}
+
+	/**
+	 * This adds the byline field to the existing $fields definition
+	 *
+	 * @param $fields
+	 *
+	 * @return mixed
+	 */
+	public function post_object_fields( $fields ) {
+
+		$fields['bylines'] = [
+			'type'        => Types::list_of( self::byline_type() ),
+			'description' => __( 'The bylines for the object' ),
+			'resolve'     => function( \WP_Post $post, array $args, AppContext $context, ResolveInfo $info ) {
+				$bylines = get_bylines( $post );
+
+				return ! empty( $bylines ) ? $bylines : null;
+			}
+		];
+
+		return $fields;
+	}
+
+	/**
+	 * This returns the definition for the BylineType, but ensures to only instantiate once
+	 *
+	 * @return BylineType
+	 */
+	public static function byline_type() {
+		return self::$byline_type ? : ( self::$byline_type = new BylineType() );
+	}
+
+	/**
+	 * This filters the post object query args so that if the source of the query is a byline, the query should
+	 * be performed with a tax_query for the source byline.
+	 *
+	 * @param array       $query_args The query_args that will be returned
+	 * @param array       $args       Query "where" args
+	 * @param mixed       $source     The query results for a query calling this
+	 * @param AppContext  $context    The AppContext object
+	 * @param ResolveInfo $info       The ResolveInfo object
+	 *
+	 * @return mixed
+	 */
+	public static function filter_byline_post_object_query_args( $query_args, $source, $args, $context, $info ) {
+
+		/**
+		 * If the source of the query is a Byline, add tax_query args
+		 */
+		if ( true === is_object( $source ) ) {
+			switch ( true ) {
+				case $source instanceof Byline:
+					$query_args['tax_query'] = [
+						[
+							'taxonomy' => 'byline',
+							'terms'    => [ $source->term_id ],
+							'field'    => 'term_id',
+						],
+					];
+					break;
+				default:
+					break;
+			}
+		}
+
+		/**
+		 * Return the $query_args
+		 */
+		return $query_args;
+	}
+
+	/**
+	 * This filters the node resolver to properly resolve with the Byline object if the $type is "byline"
+	 *
+	 * @param $node
+	 * @param $id
+	 * @param $type
+	 *
+	 * @return Byline|false
+	 */
+	public function filter_resolve_node( $node, $id, $type ) {
+		if ( ! empty( $type ) && 'byline' === $type ) {
+			return Byline::get_by_term_id( $id );
+		}
+		return $node;
+	}
+
+	/**
+	 * This filters the node_type to ensure that the Byline "type" is returned if the object being returned is
+	 * a Byline object
+	 *
+	 * @param $type
+	 * @param $node
+	 *
+	 * @return BylineType
+	 */
+	public function filter_resolve_node_type( $type, $node ) {
+		if ( is_object( $node ) && $node instanceof Byline ) {
+			return self::byline_type();
+		}
+		return $type;
+	}
+
+}

--- a/src/Integrations/GraphQL/GraphQL.php
+++ b/src/Integrations/GraphQL/GraphQL.php
@@ -61,7 +61,7 @@ class GraphQL {
 			if ( in_array( $post_type, $graphql_post_types, true ) ) {
 				add_filter( "graphql_{$post_type}_fields", array(
 					'Bylines\Integrations\GraphQL\GraphQL',
-					'post_object_fields'
+					'post_object_fields',
 				), 10, 1 );
 			}
 		}

--- a/src/Integrations/GraphQL/Type/BylineType.php
+++ b/src/Integrations/GraphQL/Type/BylineType.php
@@ -21,12 +21,14 @@ class BylineType extends WPObjectType {
 
 	/**
 	 * This holds the $fields definition for the BylineType
-	 * @var
+	 *
+	 * @var array
 	 */
 	private static $fields;
 
 	/**
 	 * This holds the name of the type
+	 *
 	 * @var string
 	 */
 	private static $type_name;
@@ -42,7 +44,7 @@ class BylineType extends WPObjectType {
 
 		$config = [
 			'name' => self::$type_name,
-			'description' =>  __( 'The Byline object type', 'bylines' ),
+			'description' => __( 'The Byline object type', 'bylines' ),
 			'fields' => self::fields(),
 			'interfaces' => [ self::node_interface() ],
 		];
@@ -128,10 +130,10 @@ class BylineType extends WPObjectType {
 				 * Add a postObjectConnection field to the byline for each post_type that supports bylines
 				 */
 				foreach ( $byline_post_types as $post_type ) {
-					if ( in_array( $post_type, $graphql_post_types, true ) ) {
+					if ( in_array( $post_type, $graphql_post_types, true ) ) :
 						$post_type_object = get_post_type_object( $post_type );
 						$fields[ $post_type_object->graphql_plural_name ] = PostObjectConnectionDefinition::connection( $post_type_object );
-					}
+					endif;
 				}
 
 				/**

--- a/src/Integrations/GraphQL/Type/BylineType.php
+++ b/src/Integrations/GraphQL/Type/BylineType.php
@@ -1,0 +1,153 @@
+<?php
+namespace Bylines\Integrations\GraphQL\Type;
+
+use Bylines\Content_Model;
+use Bylines\Objects\Byline;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQLRelay\Relay;
+use WPGraphQL\AppContext;
+use WPGraphQL\Type\PostObject\Connection\PostObjectConnectionDefinition;
+use WPGraphQL\Type\WPObjectType;
+use WPGraphQL\Types;
+
+/**
+ * Class BylineType
+ *
+ * This defines the BylineType for use in the WPGraphQL schema.
+ *
+ * @package Bylines\Integrations\GraphQL\Type
+ */
+class BylineType extends WPObjectType {
+
+	/**
+	 * This holds the $fields definition for the BylineType
+	 * @var
+	 */
+	private static $fields;
+
+	/**
+	 * This holds the name of the type
+	 * @var string
+	 */
+	private static $type_name;
+
+	/**
+	 * BylineType constructor.
+	 *
+	 * @param array $config
+	 */
+	public function __construct( array $config = [] ) {
+
+		self::$type_name = 'byline';
+
+		$config = [
+			'name' => self::$type_name,
+			'description' =>  __( 'The Byline object type', 'bylines' ),
+			'fields' => self::fields(),
+			'interfaces' => [ self::node_interface() ],
+		];
+
+		parent::__construct( $config );
+	}
+
+	/**
+	 * This creates the $fields configuration for the BylineType
+	 *
+	 * @return \Closure|null
+	 */
+	public function fields() {
+
+		if ( null === self::$fields ) {
+
+			/**
+			 * Get the supported post_types for GraphQL and Bylines
+			 */
+			$byline_post_types = Content_Model::get_byline_supported_post_types();
+			$graphql_post_types = \WPGraphQL::get_allowed_post_types();
+
+			self::$fields = function() use ( $byline_post_types, $graphql_post_types ) {
+
+				$fields = [
+					'id'                => [
+						'type'    => Types::non_null( Types::id() ),
+						'resolve' => function( Byline $byline, $args, AppContext $context, ResolveInfo $info ) {
+							return ! empty( $byline->term_id ) ? Relay::toGlobalId( 'byline', $byline->term_id ) : null;
+						},
+					],
+					'displayName' => [
+						'type' => Types::string(),
+						'description' => __( 'The display name of the byline', 'bylines' ),
+						'resolve' => function( Byline $byline, $args, AppContext $context, ResolveInfo $info ) {
+							$name = $byline->display_name;
+							return ! empty( $name ) ? esc_html( $name ) : null;
+						},
+					],
+					'firstName' => [
+						'type' => Types::string(),
+						'description' => __( 'The first name of the byline', 'bylines' ),
+						'resolve' => function( Byline $byline, $args, AppContext $context, ResolveInfo $info ) {
+							$first_name = $byline->first_name;
+							return ! empty( $first_name ) ? esc_html( $first_name ) : null;
+						},
+					],
+					'lastName' => [
+						'type' => Types::string(),
+						'description' => __( 'The last name of the byline', 'bylines' ),
+						'resolve' => function( Byline $byline, $args, AppContext $context, ResolveInfo $info ) {
+							$last_name = $byline->last_name;
+							return ! empty( $last_name ) ? esc_html( $last_name ) : null;
+						},
+					],
+					'bio' => [
+						'type' => Types::string(),
+						'description' => __( 'The biographical information for the byline', 'bylines' ),
+						'resolve' => function( Byline $byline, $args, AppContext $context, ResolveInfo $info ) {
+							$description = $byline->description;
+							return ! empty( $description ) ? esc_html( $description ) : null;
+						},
+					],
+					'email' => [
+						'type' => Types::string(),
+						'description' => __( 'The email associated with the byline', 'bylines' ),
+						'resolve' => function( Byline $byline, $args, AppContext $context, ResolveInfo $info ) {
+							$email = $byline->user_email;
+							return ! empty( $email ) ? esc_html( $email ) : null;
+						},
+					],
+					'url' => [
+						'type' => Types::string(),
+						'description' => __( 'The url (web address) associated with the byline', 'bylines' ),
+						'resolve' => function( Byline $byline, $args, AppContext $context, ResolveInfo $info ) {
+							$url = $byline->user_url;
+							return ! empty( $url ) ? esc_html( $url ) : null;
+						},
+					],
+				];
+
+				/**
+				 * Add a postObjectConnection field to the byline for each post_type that supports bylines
+				 */
+				foreach ( $byline_post_types as $post_type ) {
+					if ( in_array( $post_type, $graphql_post_types, true ) ) {
+						$post_type_object = get_post_type_object( $post_type );
+						$fields[ $post_type_object->graphql_plural_name ] = PostObjectConnectionDefinition::connection( $post_type_object );
+					}
+				}
+
+				/**
+				 * Prepare the fields for use by WPGraphQL
+				 */
+				return self::prepare_fields( $fields, self::$type_name );
+
+			};
+
+		}
+
+		/**
+		 * Return the fields
+		 */
+		return ! empty( self::$fields ) ? self::$fields : null;
+
+	}
+
+}

--- a/src/Integrations/GraphQL/Type/BylineType.php
+++ b/src/Integrations/GraphQL/Type/BylineType.php
@@ -59,7 +59,7 @@ class BylineType extends WPObjectType {
 	 */
 	public function fields() {
 
-		if ( null === self::$fields ) {
+		if ( null === self::$fields ) :
 
 			/**
 			 * Get the supported post_types for GraphQL and Bylines
@@ -143,7 +143,7 @@ class BylineType extends WPObjectType {
 
 			};
 
-		}
+		endif;
 
 		/**
 		 * Return the fields

--- a/src/Objects/Byline.php
+++ b/src/Objects/Byline.php
@@ -19,7 +19,7 @@ class Byline {
 	 *
 	 * @var integer
 	 */
-	private $term_id;
+	public $term_id;
 
 	/**
 	 * Create a new byline object


### PR DESCRIPTION
This defines a WPGraphQL type for Bylines and hooks into the GraphQL schema for postTypeObjects, so that bylines can be queried from within postTypeObject selection sets