### PR TITLE
Use proper capabilties around byline management

### DIFF
--- a/src/Content_Model.php
+++ b/src/Content_Model.php
@@ -43,6 +43,12 @@ class Content_Model {
 			'args'         => array(
 				'orderby' => 'term_order',
 			),
+			'capabilities' => array(
+				'manage_terms' => 'list_users',
+				'edit_terms'   => 'list_users',
+				'delete_terms' => 'list_users',
+				'assign_terms' => 'edit_others_posts',
+			),
 			'show_ui'      => true,
 			'show_in_quick_edit' => false,
 			'meta_box_cb'  => false,

--- a/src/Post_Editor.php
+++ b/src/Post_Editor.php
@@ -100,15 +100,16 @@ class Post_Editor {
 			}
 			?>
 		</ul>
-		<select data-nonce="<?php echo esc_attr( wp_create_nonce( 'bylines-search' ) ); ?>" class="bylines-select2 bylines-search" style="min-width: 200px"></select>
-		<script type="text/html" id="tmpl-bylines-byline-partial">
-			<?php echo self::get_rendered_byline_partial( array(
-				'display_name' => '{{ data.display_name }}',
-				'avatar_url'   => '{{ data.avatar_url }}',
-				'term'         => '{{ data.term }}',
-			) ); ?>
-		</script>
-		<?php
+		<?php if ( current_user_can( get_taxonomy( 'byline' )->cap->assign_terms ) ) : ?>
+			<select data-nonce="<?php echo esc_attr( wp_create_nonce( 'bylines-search' ) ); ?>" class="bylines-select2 bylines-search" style="min-width: 200px"></select>
+			<script type="text/html" id="tmpl-bylines-byline-partial">
+				<?php echo self::get_rendered_byline_partial( array(
+					'display_name' => '{{ data.display_name }}',
+					'avatar_url'   => '{{ data.avatar_url }}',
+					'term'         => '{{ data.term }}',
+				) ); ?>
+			</script>
+		<?php endif;
 	}
 
 	/**
@@ -123,8 +124,7 @@ class Post_Editor {
 			return;
 		}
 
-		// @todo verify user can edit bylines on this post.
-		if ( ! isset( $_POST['bylines'] ) ) {
+		if ( ! isset( $_POST['bylines'] ) || ! current_user_can( get_taxonomy( 'byline' )->cap->assign_terms ) ) {
 			return;
 		}
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -97,7 +97,7 @@ class Query {
 			$terms_implode = rtrim( $terms_implode, ' OR' );
 			$query->bylines_having_terms = rtrim( $query->bylines_having_terms, ' OR' );
 			// post_author = 2 OR post_author IN (2).
-			$regex = '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*(=\s*[\d+]|IN\s*\([\d+]\)))/';
+			$regex = '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*(=\s*[\d]+|IN\s*\([\d]+\)))/';
 			$where = preg_replace( $regex, '(' . $maybe_both_query . ' ' . $terms_implode . ')', $where );
 		}
 

--- a/tests/test-bylines-permissions.php
+++ b/tests/test-bylines-permissions.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Test functionality related to byline editing permissions
+ *
+ * @package Bylines
+ */
+
+use Bylines\Objects\Byline;
+use Bylines\Utils;
+
+/**
+ * Class Test_Bylines_Permissions
+ */
+class Test_Bylines_Permissions extends WP_UnitTestCase {
+
+	/**
+	 * Contributors shouldn't be able to assign or edit bylines
+	 */
+	public function test_permissions_contributors_cannot_assign_bylines() {
+		$user_id = $this->factory->user->create( array(
+			'role' => 'contributor',
+		) );
+		wp_set_current_user( $user_id );
+		$taxonomy = get_taxonomy( 'byline' );
+		$this->assertFalse( current_user_can( $taxonomy->cap->manage_terms ) );
+		$this->assertFalse( current_user_can( $taxonomy->cap->edit_terms ) );
+		$this->assertFalse( current_user_can( $taxonomy->cap->delete_terms ) );
+		$this->assertFalse( current_user_can( $taxonomy->cap->assign_terms ) );
+	}
+
+	/**
+	 * Editors should be able to assign bylines, but not edit because they don't have 'list_users'
+	 */
+	public function test_permissions_editors_can_assign_bylines_but_not_edit() {
+		$user_id = $this->factory->user->create( array(
+			'role' => 'editor',
+		) );
+		wp_set_current_user( $user_id );
+		$taxonomy = get_taxonomy( 'byline' );
+		$this->assertFalse( current_user_can( $taxonomy->cap->manage_terms ) );
+		$this->assertFalse( current_user_can( $taxonomy->cap->edit_terms ) );
+		$this->assertFalse( current_user_can( $taxonomy->cap->delete_terms ) );
+		$this->assertTrue( current_user_can( $taxonomy->cap->assign_terms ) );
+	}
+
+	/**
+	 * Administrators should be able to edit bylines, because they have 'list_users'
+	 */
+	public function test_permissions_administrators_can_edit_bylines() {
+		$user_id = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+		wp_set_current_user( $user_id );
+		$taxonomy = get_taxonomy( 'byline' );
+		$this->assertTrue( current_user_can( $taxonomy->cap->manage_terms ) );
+		$this->assertTrue( current_user_can( $taxonomy->cap->edit_terms ) );
+		$this->assertTrue( current_user_can( $taxonomy->cap->delete_terms ) );
+		$this->assertTrue( current_user_can( $taxonomy->cap->assign_terms ) );
+	}
+
+}

--- a/tests/test-bylines.php
+++ b/tests/test-bylines.php
@@ -17,6 +17,10 @@ class Test_Bylines extends WP_UnitTestCase {
 	 * Saving bylines generically
 	 */
 	public function test_save_bylines() {
+		$user_id = $this->factory->user->create( array(
+			'role' => 'editor',
+		) );
+		wp_set_current_user( $user_id );
 		$post_id = $this->factory->post->create();
 		$b1 = Byline::create( array(
 			'slug'  => 'b1',
@@ -43,6 +47,10 @@ class Test_Bylines extends WP_UnitTestCase {
 	 * Saving bylines by creating a new user
 	 */
 	public function test_save_bylines_create_new_user() {
+		$user_id = $this->factory->user->create( array(
+			'role' => 'editor',
+		) );
+		wp_set_current_user( $user_id );
 		$post_id = $this->factory->post->create();
 		$b1 = Byline::create( array(
 			'slug'  => 'b1',
@@ -73,6 +81,10 @@ class Test_Bylines extends WP_UnitTestCase {
 	 * Saving bylines by repurposing an existing user
 	 */
 	public function test_save_bylines_existing_user() {
+		$user_id = $this->factory->user->create( array(
+			'role' => 'editor',
+		) );
+		wp_set_current_user( $user_id );
 		$post_id = $this->factory->post->create();
 		$b1 = Byline::create( array(
 			'slug'  => 'b1',


### PR DESCRIPTION
Assigning bylines requires `edit_others_posts`. Managing bylines
(editing and deleting) requires `list_users`.

See #22