### PR TITLE
Add type=>image to Bylines

### DIFF
--- a/assets/js/bylines.js
+++ b/assets/js/bylines.js
@@ -47,13 +47,13 @@
 			});
 		});
 
-		$('.custom-img-wrapper').each(function(){
+		$('.byline-image-field-wrapper').each(function(){
 			var frame,
 			target = $(this), // Your meta box id here
-			deleteImgLink = target.find('.select-custom-img'),
-			delImgLink = target.find( '.delete-custom-img'),
-			imgContainer = target.find( '.custom-img-container'),
-			imgIdInput = target.find( '.custom-img-id' );
+			deleteImgLink = target.find('.select-byline-image-field'),
+			delImgLink = target.find( '.delete-byline-image-field'),
+			imgContainer = target.find( '.byline-image-field-container'),
+			imgIdInput = target.find( '.byline-image-field-id' );
 
 			deleteImgLink.on( 'click', function( event ){
 				event.preventDefault();
@@ -63,9 +63,9 @@
 					return;
 				}
 				frame = wp.media({
-					title: 'Select or Upload Image Of Your Chosen Person',
+					title: bylines.media_upload_title,
 					button: {
-						text: 'Use this image'
+						text: bylines.media_upload_button
 					},
 					multiple: false,
 					library : {
@@ -74,7 +74,9 @@
 				});
 				frame.on( 'select', function() {
 					var attachment = frame.state().get('selection').first().toJSON();
-					imgContainer.append( '<img src="'+attachment.sizes.thumbnail.url+'" />' );
+					var imgEl = $('<img />');
+					imgEl.attr('src', attachment.sizes.thumbnail.url );
+					imgContainer.append( imgEl );
 					imgIdInput.val( attachment.id );
 					deleteImgLink.addClass( 'hidden' );
 					delImgLink.removeClass( 'hidden' );

--- a/assets/js/bylines.js
+++ b/assets/js/bylines.js
@@ -63,9 +63,9 @@
 					return;
 				}
 				frame = wp.media({
-					title: 'Select or Upload Media Of Your Chosen Persuasion',
+					title: 'Select or Upload Image Of Your Chosen Person',
 					button: {
-						text: 'Use this media'
+						text: 'Use this image'
 					},
 					multiple: false,
 					library : {
@@ -73,7 +73,6 @@
 					}
 				});
 				frame.on( 'select', function() {
-					console.log(frame);
 					var attachment = frame.state().get('selection').first().toJSON();
 					imgContainer.append( '<img src="'+attachment.sizes.thumbnail.url+'" />' );
 					imgIdInput.val( attachment.id );

--- a/assets/js/bylines.js
+++ b/assets/js/bylines.js
@@ -46,6 +46,54 @@
 				},
 			});
 		});
+
+		$('.custom-img-wrapper').each(function(){
+			var frame,
+			target = $(this), // Your meta box id here
+			deleteImgLink = target.find('.select-custom-img'),
+			delImgLink = target.find( '.delete-custom-img'),
+			imgContainer = target.find( '.custom-img-container'),
+			imgIdInput = target.find( '.custom-img-id' );
+
+			deleteImgLink.on( 'click', function( event ){
+				event.preventDefault();
+
+				if ( frame ) {
+					frame.open();
+					return;
+				}
+				frame = wp.media({
+					title: 'Select or Upload Media Of Your Chosen Persuasion',
+					button: {
+						text: 'Use this media'
+					},
+					multiple: false,
+					library : {
+						type : 'image'
+					}
+				});
+				frame.on( 'select', function() {
+					console.log(frame);
+					var attachment = frame.state().get('selection').first().toJSON();
+					imgContainer.append( '<img src="'+attachment.sizes.thumbnail.url+'" />' );
+					imgIdInput.val( attachment.id );
+					deleteImgLink.addClass( 'hidden' );
+					delImgLink.removeClass( 'hidden' );
+				});
+
+				frame.open();
+			});
+
+			delImgLink.on( 'click', function( event ){
+				event.preventDefault();
+				imgContainer.html( '' );
+				deleteImgLink.removeClass( 'hidden' );
+				delImgLink.addClass( 'hidden' );
+				imgIdInput.val( '' );
+			});
+		
+		});
+	
 	});
 
 }(jQuery))

--- a/bylines.php
+++ b/bylines.php
@@ -57,7 +57,6 @@ add_filter( 'manage_byline_custom_column', array( 'Bylines\Byline_Editor', 'filt
 add_filter( 'user_row_actions', array( 'Bylines\Byline_Editor', 'filter_user_row_actions' ), 10, 2 );
 add_action( 'byline_edit_form_fields', array( 'Bylines\Byline_Editor', 'action_byline_edit_form_fields' ) );
 add_action( 'edited_byline', array( 'Bylines\Byline_Editor', 'action_edited_byline' ) );
-add_action( 'admin_enqueue_scripts', array( 'Bylines\Byline_Editor', 'admin_enqueue_scripts' ) );
 
 // Query modifications.
 add_action( 'pre_get_posts', array( 'Bylines\Query', 'action_pre_get_posts' ) );

--- a/bylines.php
+++ b/bylines.php
@@ -57,6 +57,7 @@ add_filter( 'manage_byline_custom_column', array( 'Bylines\Byline_Editor', 'filt
 add_filter( 'user_row_actions', array( 'Bylines\Byline_Editor', 'filter_user_row_actions' ), 10, 2 );
 add_action( 'byline_edit_form_fields', array( 'Bylines\Byline_Editor', 'action_byline_edit_form_fields' ) );
 add_action( 'edited_byline', array( 'Bylines\Byline_Editor', 'action_edited_byline' ) );
+add_action( 'admin_enqueue_scripts', array( 'Bylines\Byline_Editor', 'admin_enqueue_scripts' ) );
 
 // Query modifications.
 add_action( 'pre_get_posts', array( 'Bylines\Query', 'action_pre_get_posts' ) );

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -24,13 +24,22 @@ class Assets {
 			return;
 		}
 
+		if ( 'term' === $screen->base ) {
+			wp_enqueue_media();
+		}
+
 		wp_enqueue_script( 'bylines-select2', plugins_url( 'assets/lib/select2/js/select2.min.js', dirname( __FILE__ ) ), array( 'jquery' ), '4.0.3' );
 		wp_add_inline_script( 'bylines-select2', 'var existingSelect2 = jQuery.fn.select2 || null; if (existingSelect2) { delete jQuery.fn.select2; }', 'before' );
 		wp_add_inline_script( 'bylines-select2', 'jQuery.fn["bylinesSelect2"] = jQuery.fn.select2; if (existingSelect2) { delete jQuery.fn.select2; jQuery.fn.select2 = existingSelect2; }', 'after' );
 		wp_enqueue_style( 'bylines-select2', plugins_url( 'assets/lib/select2/css/select2.min.css', dirname( __FILE__ ) ), array(), '4.0.3' );
 
+		$bylines_script_translation = array(
+			'media_upload_title' => __( 'Select or Upload Image to Your Chosen Byline', 'bylines' ),
+			'media_upload_button' => __( 'Use this image', 'bylines' ),
+		);
 		$mtime = filemtime( dirname( dirname( __FILE__ ) ) . '/assets/js/bylines.js' );
 		wp_enqueue_script( 'bylines', plugins_url( 'assets/js/bylines.js?mtime=' . $mtime, dirname( __FILE__ ) ), array( 'jquery', 'bylines-select2', 'jquery-ui-core', 'jquery-ui-sortable' ) );
+		wp_localize_script( 'bylines', 'bylines', $bylines_script_translation );
 		$mtime = filemtime( dirname( dirname( __FILE__ ) ) . '/assets/css/bylines.css' );
 		wp_enqueue_style( 'bylines', plugins_url( 'assets/css/bylines.css?mtime=' . $mtime, dirname( __FILE__ ) ) );
 	}

--- a/src/Byline_Editor.php
+++ b/src/Byline_Editor.php
@@ -15,6 +15,13 @@ use Bylines\Objects\Byline;
 class Byline_Editor {
 
 	/**
+	 * Enque media scripts
+	 */
+	public static function admin_enqueue_scripts() {
+		wp_enqueue_media();
+	}
+
+	/**
 	 * Customize the term table to look more like the users table.
 	 *
 	 * @param array $columns Columns to render in the list table.
@@ -142,7 +149,7 @@ class Byline_Editor {
 	 * @param Byline $byline Byline to be rendered.
 	 * @return array
 	 */
-	public static function get_fields( $byline ) {
+	public static function get_fields( $byline = null ) {
 		$fields = array(
 			'first_name'   => array(
 				'label'    => __( 'First Name', 'bylines' ),
@@ -155,6 +162,10 @@ class Byline_Editor {
 			'user_email'   => array(
 				'label'    => __( 'Email', 'bylines' ),
 				'type'     => 'email',
+			),
+			'user_image'   => array(
+				'label'    => __( 'Image', 'bylines' ),
+				'type'     => 'image',
 			),
 			'user_id'      => array(
 				'label'    => __( 'Mapped User', 'bylines' ),
@@ -204,7 +215,25 @@ class Byline_Editor {
 				<?php endif; ?>
 			</th>
 			<td>
-				<?php if ( 'textarea' === $args['type'] ) : ?>
+				<?php if ( 'image' === $args['type'] ) :
+					$custom_img = wp_get_attachment_image_src( $args['value'], 'thumbnail' ); ?>
+					<div class="custom-img-wrapper">
+						<div class="custom-img-container">
+						<?php if ( $custom_img ) : ?>
+							<img src="<?php echo esc_url( $custom_img[0] ); ?>" alt="" />
+						<?php endif; ?>
+						</div>
+						<p class="hide-if-no-js">
+							<a class="select-custom-img <?php if ( $custom_img ) { echo 'hidden'; } ?>" href="#">
+								<?php _e('Select image', 'bylines'); ?>
+							</a>
+							<a class="delete-custom-img <?php if ( ! $custom_img ) { echo 'hidden'; } ?>" href="#">
+								<?php _e('Remove this image', 'bylines') ?>
+							</a>
+						</p>
+						<input name="<?php echo esc_attr( $key ); ?>" class="custom-img-id" type="hidden" value="<?php echo esc_attr( $args['value'] ); ?>" />
+					</div>
+				<?php elseif ( 'textarea' === $args['type'] ) : ?>
 					<textarea name="<?php echo esc_attr( $key ); ?>"><?php echo esc_textarea( $args['value'] ); ?></textarea>
 				<?php elseif ( 'ajax_user_select' === $args['type'] ) :
 					$user = ! empty( $args['value'] ) ? get_user_by( 'id', $args['value'] ) : false;

--- a/src/Byline_Editor.php
+++ b/src/Byline_Editor.php
@@ -15,13 +15,6 @@ use Bylines\Objects\Byline;
 class Byline_Editor {
 
 	/**
-	 * Enque media scripts
-	 */
-	public static function admin_enqueue_scripts() {
-		wp_enqueue_media();
-	}
-
-	/**
 	 * Customize the term table to look more like the users table.
 	 *
 	 * @param array $columns Columns to render in the list table.
@@ -134,7 +127,8 @@ class Byline_Editor {
 			|| ! wp_verify_nonce( $_POST['byline-edit-nonce'], 'byline-edit' ) ) {
 			return;
 		}
-		foreach ( self::get_fields() as $key => $args ) {
+		$byline = Byline::get_by_term_id( $term->term_id );
+		foreach ( self::get_fields( $byline ) as $key => $args ) {
 			if ( ! isset( $_POST[ 'bylines-' . $key ] ) ) {
 				continue;
 			}
@@ -149,7 +143,7 @@ class Byline_Editor {
 	 * @param Byline $byline Byline to be rendered.
 	 * @return array
 	 */
-	public static function get_fields( $byline = null ) {
+	public static function get_fields( $byline ) {
 		$fields = array(
 			'first_name'   => array(
 				'label'    => __( 'First Name', 'bylines' ),
@@ -162,10 +156,6 @@ class Byline_Editor {
 			'user_email'   => array(
 				'label'    => __( 'Email', 'bylines' ),
 				'type'     => 'email',
-			),
-			'user_avatar'   => array(
-				'label'    => __( 'Avatar', 'bylines' ),
-				'type'     => 'image',
 			),
 			'user_id'      => array(
 				'label'    => __( 'Mapped User', 'bylines' ),
@@ -216,22 +206,22 @@ class Byline_Editor {
 			</th>
 			<td>
 				<?php if ( 'image' === $args['type'] ) :
-					$custom_img = wp_get_attachment_image_url( $args['value'], 'thumbnail' ); ?>
-					<div class="custom-img-wrapper">
-						<div class="custom-img-container">
-						<?php if ( $custom_img ) : ?>
-							<img src="<?php echo esc_url( $custom_img ); ?>" alt="" />
+					$byline_image = wp_get_attachment_image_url( $args['value'], 'thumbnail' ); ?>
+					<div class="byline-image-field-wrapper">
+						<div class="byline-image-field-container">
+						<?php if ( $byline_image ) : ?>
+							<img src="<?php echo esc_url( $byline_image ); ?>" alt="" />
 						<?php endif; ?>
 						</div>
 						<p class="hide-if-no-js">
-							<a class="select-custom-img <?php if ( $custom_img ) { echo 'hidden'; } ?>" href="#">
+							<a class="select-byline-image-field <?php if ( $byline_image ) { echo 'hidden'; } ?>" href="#">
 								<?php _e( 'Select image', 'bylines' ); ?>
 							</a>
-							<a class="delete-custom-img <?php if ( ! $custom_img ) { echo 'hidden'; } ?>" href="#">
+							<a class="delete-byline-image-field <?php if ( ! $byline_image ) { echo 'hidden'; } ?>" href="#">
 								<?php _e( 'Remove this image', 'bylines' ) ?>
 							</a>
 						</p>
-						<input name="<?php echo esc_attr( $key ); ?>" class="custom-img-id" type="hidden" value="<?php echo esc_attr( $args['value'] ); ?>" />
+						<input name="<?php echo esc_attr( $key ); ?>" class="byline-image-field-id" type="hidden" value="<?php echo esc_attr( $args['value'] ); ?>" />
 					</div>
 				<?php elseif ( 'textarea' === $args['type'] ) : ?>
 					<textarea name="<?php echo esc_attr( $key ); ?>"><?php echo esc_textarea( $args['value'] ); ?></textarea>

--- a/src/Byline_Editor.php
+++ b/src/Byline_Editor.php
@@ -163,8 +163,8 @@ class Byline_Editor {
 				'label'    => __( 'Email', 'bylines' ),
 				'type'     => 'email',
 			),
-			'user_image'   => array(
-				'label'    => __( 'Image', 'bylines' ),
+			'user_avatar'   => array(
+				'label'    => __( 'Avatar', 'bylines' ),
 				'type'     => 'image',
 			),
 			'user_id'      => array(
@@ -216,11 +216,11 @@ class Byline_Editor {
 			</th>
 			<td>
 				<?php if ( 'image' === $args['type'] ) :
-					$custom_img = wp_get_attachment_image_src( $args['value'], 'thumbnail' ); ?>
+					$custom_img = wp_get_attachment_image_url( $args['value'], 'thumbnail' ); ?>
 					<div class="custom-img-wrapper">
 						<div class="custom-img-container">
 						<?php if ( $custom_img ) : ?>
-							<img src="<?php echo esc_url( $custom_img[0] ); ?>" alt="" />
+							<img src="<?php echo esc_url( $custom_img ); ?>" alt="" />
 						<?php endif; ?>
 						</div>
 						<p class="hide-if-no-js">

--- a/src/Byline_Editor.php
+++ b/src/Byline_Editor.php
@@ -225,10 +225,10 @@ class Byline_Editor {
 						</div>
 						<p class="hide-if-no-js">
 							<a class="select-custom-img <?php if ( $custom_img ) { echo 'hidden'; } ?>" href="#">
-								<?php _e('Select image', 'bylines'); ?>
+								<?php _e( 'Select image', 'bylines' ); ?>
 							</a>
 							<a class="delete-custom-img <?php if ( ! $custom_img ) { echo 'hidden'; } ?>" href="#">
-								<?php _e('Remove this image', 'bylines') ?>
+								<?php _e( 'Remove this image', 'bylines' ) ?>
 							</a>
 						</p>
 						<input name="<?php echo esc_attr( $key ); ?>" class="custom-img-id" type="hidden" value="<?php echo esc_attr( $args['value'] ); ?>" />


### PR DESCRIPTION
As a reply to #62 this pull request adds field type "image". From the Byline Editor it will call for wp.media, filtering by _images only_ and let the user upload/select/remove one image per _field_ of type image.