### PR TITLE
Fallback if thumbnails does not exist

### DIFF
--- a/assets/css/bylines.css
+++ b/assets/css/bylines.css
@@ -39,3 +39,7 @@ ul.bylines-list.bylines-current-user-can-assign li .byline-remove {
   float: left;
   margin-right: 10px;
   margin-top: 1px; }
+
+.byline-image-field-container img {
+  max-width: 150px;
+  height: auto; }

--- a/assets/css/scss/bylines.scss
+++ b/assets/css/scss/bylines.scss
@@ -51,3 +51,10 @@ ul.bylines-list {
 		margin-top: 1px;
 	}
 }
+
+.byline-image-field-container {
+	img {
+		max-width: 150px;
+		height: auto;
+	}
+}

--- a/assets/js/bylines.js
+++ b/assets/js/bylines.js
@@ -74,8 +74,9 @@
 				});
 				frame.on( 'select', function() {
 					var attachment = frame.state().get('selection').first().toJSON();
+					var attachment_src = ( "undefined" === typeof attachment.sizes.thumbnail ? attachment.url : attachment.sizes.thumbnail.url );
 					var imgEl = $('<img />');
-					imgEl.attr('src', attachment.sizes.thumbnail.url );
+					imgEl.attr('src', attachment_src );
 					imgContainer.append( imgEl );
 					imgIdInput.val( attachment.id );
 					deleteImgLink.addClass( 'hidden' );


### PR DESCRIPTION
We noticed that in some rare cases when imported media is used the wp.media does not return an object as expected. So this pull request offers a fallback that returns the original attachment url.