### PR TITLE
Referring to the wrong variable 

### DIFF
--- a/src/Byline_Editor.php
+++ b/src/Byline_Editor.php
@@ -127,7 +127,7 @@ class Byline_Editor {
 			|| ! wp_verify_nonce( $_POST['byline-edit-nonce'], 'byline-edit' ) ) {
 			return;
 		}
-		$byline = Byline::get_by_term_id( $term->term_id );
+		$byline = Byline::get_by_term_id( $term_id );
 		foreach ( self::get_fields( $byline ) as $key => $args ) {
 			if ( ! isset( $_POST[ 'bylines-' . $key ] ) ) {
 				continue;


### PR DESCRIPTION
I was sloppy and referred to the wrong variable when I was trying to solve the problem with get_fields without attributes. This pull request fixes that.