### PR TITLE
Permit removing last byline in editor by setting post_author=0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 
 language: php
 
@@ -34,6 +35,7 @@ matrix:
       env: WP_TRAVISCI=behat
     - php: 5.3
       env: WP_VERSION=latest
+      dist: precise
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/tests/phpunit/test-bylines.php
+++ b/tests/phpunit/test-bylines.php
@@ -60,6 +60,7 @@ class Test_Bylines extends Bylines_Testcase {
 				$b1->term_id,
 				$b2->term_id,
 			),
+			'bylines-save' => wp_create_nonce( 'bylines-save' ),
 		);
 		do_action( 'save_post', $post_id, get_post( $post_id ), true );
 		$bylines = get_bylines( $post_id );
@@ -97,6 +98,7 @@ class Test_Bylines extends Bylines_Testcase {
 				'u' . $user_id,
 				$b1->term_id,
 			),
+			'bylines-save' => wp_create_nonce( 'bylines-save' ),
 		);
 		do_action( 'save_post', $post_id, get_post( $post_id ), true );
 		$bylines = get_bylines( $post_id );
@@ -138,11 +140,39 @@ class Test_Bylines extends Bylines_Testcase {
 				'u' . $user_id,
 				$b1->term_id,
 			),
+			'bylines-save' => wp_create_nonce( 'bylines-save' ),
 		);
 		do_action( 'save_post', $post_id, get_post( $post_id ), true );
 		$bylines = get_bylines( $post_id );
 		$this->assertCount( 2, $bylines );
 		$this->assertEquals( array( 'foobar', 'b1' ), wp_list_pluck( $bylines, 'slug' ) );
+	}
+
+	/**
+	 * Saving a post without any bylines
+	 */
+	public function test_save_bylines_none() {
+		$user_id = $this->factory->user->create(
+			array(
+				'role' => 'editor',
+			)
+		);
+		wp_set_current_user( $user_id );
+		$post_id = $this->factory->post->create( array(
+			'post_author' => $user_id,
+		) );
+		$this->assertEquals( $user_id, get_post( $post_id )->post_author );
+		$bylines = get_bylines( $post_id );
+		$this->assertCount( 1, $bylines );
+		// Mock a POST request.
+		$_POST = array(
+			'bylines' => array(),
+			'bylines-save' => wp_create_nonce( 'bylines-save' ),
+		);
+		do_action( 'save_post', $post_id, get_post( $post_id ), true );
+		$bylines = get_bylines( $post_id );
+		$this->assertCount( 0, $bylines );
+		$this->assertEquals( 0, get_post( $post_id )->post_author );
 	}
 
 }


### PR DESCRIPTION
By default, `get_bylines()` will return the `post_author` if a post has
no associated byline terms. This is for backwards-compat on sites that
moved to bylines after publishing some number of items. However, users
should be able to remove all bylines from a post when bylines is active.

Fixes #98