### PR TITLE
Redirect mapped accounts.

### DIFF
--- a/bylines.php
+++ b/bylines.php
@@ -50,6 +50,7 @@ add_action( 'init', array( 'Bylines\Content_Model', 'action_init_register_taxono
 add_action( 'init', array( 'Bylines\Content_Model', 'action_init_late_register_taxonomy_for_object_type' ), 100 );
 add_filter( 'term_link', array( 'Bylines\Content_Model', 'filter_term_link' ), 10, 3 );
 add_filter( 'update_term_metadata', array( 'Bylines\Content_Model', 'filter_update_term_metadata' ), 10, 4 );
+add_action( 'parse_request', array( 'Bylines\Content_Model', 'action_parse_query' ) );
 
 // Admin customizations.
 add_action( 'admin_init', array( 'Bylines\Post_Editor', 'action_admin_init' ) );

--- a/src/Content_Model.php
+++ b/src/Content_Model.php
@@ -149,7 +149,7 @@ class Content_Model {
 			return $query;
 		}
 
-		// No redirection needed on admin requests
+		// No redirection needed on admin requests.
 		if ( is_admin() ) {
 			return $query;
 		}

--- a/src/Content_Model.php
+++ b/src/Content_Model.php
@@ -138,4 +138,33 @@ class Content_Model {
 		return apply_filters( 'bylines_post_types', $post_types_with_authors );
 	}
 
+	/**
+	 * Redirect mapped accounts. If user_nicename and byline slug doesn't match,
+	 * redirect from the user_nicename to the byline slug.
+	 *
+	 * @param WP $query Current WordPress environment instance.
+	 */
+	public static function action_parse_query( $query ) {
+		if ( ! isset( $query->query_vars['author_name'] ) ) {
+			return $query;
+		}
+
+		// No redirection needed on admin requests
+		if ( is_admin() ) {
+			return $query;
+		}
+
+		$author = get_user_by( 'slug', sanitize_title( $query->query_vars['author_name'] ) );
+		if ( is_a( $author, 'WP_User' ) ) {
+			$byline = Byline::get_by_user_id( $author->ID );
+			if ( $byline && $query->query_vars['author_name'] !== $byline->slug ) {
+				if ( wp_safe_redirect( $byline->link ) ) {
+					exit;
+				}
+			}
+		}
+
+		return $query;
+	}
+
 }

--- a/tests/phpunit/class-bylines-testcase.php
+++ b/tests/phpunit/class-bylines-testcase.php
@@ -16,6 +16,15 @@ class Bylines_Testcase extends WP_UnitTestCase {
 	public function setUp() {
 		$this->setup_permalink_structure();
 		parent::setUp();
+		add_filter( 'wp_redirect', array( $this, 'filter_wp_redirect' ), 10, 2 );
+	}
+
+	/**
+	 * Tear down the tests
+	 */
+	public function tearDown() {
+		remove_filter( 'wp_redirect', array( $this, 'filter_wp_redirect' ), 10, 2 );
+		parent::tearDown();
 	}
 
 	/**
@@ -32,6 +41,17 @@ class Bylines_Testcase extends WP_UnitTestCase {
 		create_initial_taxonomies();
 
 		$wp_rewrite->flush_rules();
+	}
+
+	/**
+	 * Capture any redirects
+	 */
+	public function filter_wp_redirect( $location, $status ) {
+		$this->final_redirect_location = $location;
+		$this->go_to( $location );
+
+		// Prevent the redirect from happening
+		return false;
 	}
 
 }

--- a/tests/phpunit/class-bylines-testcase.php
+++ b/tests/phpunit/class-bylines-testcase.php
@@ -11,6 +11,14 @@
 class Bylines_Testcase extends WP_UnitTestCase {
 
 	/**
+	 * If a redirect occurs this will be set to the redirect location.
+	 *
+	 * @var string
+	 * @access protected
+	 */
+	protected $final_redirect_location = '';
+
+	/**
 	 * Set up the tests
 	 */
 	public function setUp() {

--- a/tests/phpunit/class-bylines-testcase.php
+++ b/tests/phpunit/class-bylines-testcase.php
@@ -45,12 +45,15 @@ class Bylines_Testcase extends WP_UnitTestCase {
 
 	/**
 	 * Capture any redirects
+	 *
+	 * @param string  $location The path to redirect to.
+	 * @param integer $status   Status code to use.
 	 */
 	public function filter_wp_redirect( $location, $status ) {
 		$this->final_redirect_location = $location;
 		$this->go_to( $location );
 
-		// Prevent the redirect from happening
+		// Prevent the redirect from happening.
 		return false;
 	}
 

--- a/tests/phpunit/test-bylines-query.php
+++ b/tests/phpunit/test-bylines-query.php
@@ -205,4 +205,50 @@ class Test_Bylines_Query extends Bylines_Testcase {
 		$this->assertEquals( $this->final_redirect_location, $byline->link );
 	}
 
+	/**
+	 * Request to an author archive where the user has a mapped byline with the
+	 * same slug as the user_nicename should not trigger a redirect.
+	 */
+	public function test_user_with_mapped_byline_with_same_slug_should_not_redirect() {
+		$this->user_id = $this->factory->user->create(
+			array(
+				'display_name'   => 'User',
+			)
+		);
+		$this->post_id = $this->factory->post->create(
+			array(
+				'post_author' => $this->user_id,
+			)
+		);
+		$byline = Byline::create_from_user( $this->user_id );
+		Utils::set_post_bylines( $this->post_id, array( $byline ) );
+
+		$this->go_to( get_author_posts_url( $this->user_id ) );
+
+		// $this->final_redirect_location is set in Bylines_Testcase::filter_wp_redirect
+		$this->assertAttributeEmpty( 'final_redirect_location', $this );
+	}
+
+	/**
+	 * Request to an author archive where the user has no mapped byline
+	 * should not trigger a redirect.
+	 */
+	public function test_user_without_mapped_byline_should_not_redirect() {
+		$this->user_id = $this->factory->user->create(
+			array(
+				'display_name'   => 'User',
+			)
+		);
+		$this->post_id = $this->factory->post->create(
+			array(
+				'post_author' => $this->user_id,
+			)
+		);
+
+		$this->go_to( get_author_posts_url( $this->user_id ) );
+
+		// $this->final_redirect_location is set in Bylines_Testcase::filter_wp_redirect
+		$this->assertAttributeEmpty( 'final_redirect_location', $this );
+	}
+
 }

--- a/tests/phpunit/test-bylines-query.php
+++ b/tests/phpunit/test-bylines-query.php
@@ -194,7 +194,7 @@ class Test_Bylines_Query extends Bylines_Testcase {
 		$byline = Byline::create_from_user( $this->user_id );
 		Utils::set_post_bylines( $this->post_id, array( $byline ) );
 
-		//Change byline slug to something else than user_nicename.
+		// Change byline slug to something else than user_nicename.
 		wp_update_term( $byline->term_id, 'byline', array(
 			'slug' => 'nondefaultbylineslug',
 		) );

--- a/tests/phpunit/test-bylines-query.php
+++ b/tests/phpunit/test-bylines-query.php
@@ -177,4 +177,32 @@ class Test_Bylines_Query extends Bylines_Testcase {
 		$this->assertTrue( ! isset( $GLOBALS['wp_query']->bylines_having_terms ) );
 	}
 
+	/**
+	 * Redirect to byline slug if user has mapped byline with a slug that differs from user_nicename.
+	 */
+	public function test_user_with_mapped_byline_with_different_slug_should_redirect_to_byline_slug() {
+		$this->user_id = $this->factory->user->create(
+			array(
+				'display_name'   => 'User',
+			)
+		);
+		$this->post_id = $this->factory->post->create(
+			array(
+				'post_author' => $this->user_id,
+			)
+		);
+		$byline = Byline::create_from_user( $this->user_id );
+		Utils::set_post_bylines( $this->post_id, array( $byline ) );
+
+		//Change byline slug to something else than user_nicename.
+		wp_update_term( $byline->term_id, 'byline', array(
+			'slug' => 'nondefaultbylineslug',
+		) );
+
+		$this->go_to( get_author_posts_url( $this->user_id ) );
+
+		// $this->final_redirect_location is set in Bylines_Testcase::filter_wp_redirect
+		$this->assertEquals( $this->final_redirect_location, $byline->link );
+	}
+
 }


### PR DESCRIPTION
If user_nicename and byline slug doesn't match, redirect from the user_nicename to the byline slug. See #101 